### PR TITLE
Added localhost at port 4173 to cors whitelist

### DIFF
--- a/wilderwatch/settings.py
+++ b/wilderwatch/settings.py
@@ -59,7 +59,8 @@ REST_FRAMEWORK = {
 CORS_ORIGIN_WHITELIST = (
     'http://localhost:3000',
     'http://127.0.0.1:3000',
-    'http://localhost:5173'
+    'http://localhost:5173',
+    'http://localhost:4173'
 )
 
 MIDDLEWARE = [


### PR DESCRIPTION
## Changes made
- Server can now communicate with localhost:4173 when running preview of production build